### PR TITLE
docs: fix prebuild snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ And lastly, prebuild the application so the indy-sdk can be added as native depe
 yarn expo prebuild
 
 # npm
-./node_modules/.bin/expo prebuild
+npx expo prebuild
 ```
 
 That's it, you now have Indy SDK configured for your iOS and Android project. If you're using this plugin with [Aries Framework JavaScript](https://github.com/hyperledger/aries-framework-javascript) you will still need to follow the other setup steps, but you can skip the [Installation](https://aries.js.org/guides/getting-started/installation/react-native) for React Native.

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ And lastly, prebuild the application so the indy-sdk can be added as native depe
 
 ```sh
 # yarn
-yarn prebuild
+yarn expo prebuild
 
 # npm
-npm run prebuild
+./node_modules/.bin/expo prebuild
 ```
 
 That's it, you now have Indy SDK configured for your iOS and Android project. If you're using this plugin with [Aries Framework JavaScript](https://github.com/hyperledger/aries-framework-javascript) you will still need to follow the other setup steps, but you can skip the [Installation](https://aries.js.org/guides/getting-started/installation/react-native) for React Native.


### PR DESCRIPTION
The code snippet to run the `expo prebuild` command assumes you have the following script entry in your `package.json`

```
...
"scripts": {
    "prebuild": "expo prebuild"
}
...
```
However, this isn't always the case. For example, bootstapping a project with `npx create-expo-app` won't add that entry to the `package.json`.

This PR makes the snippets more setup independent.

Signed-off-by: Karim Stekelenburg <karim@animo.id>